### PR TITLE
Avoid unnecessary copies in the buffer during parsing.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(rds2cpp
-    VERSION 1.0.1
+    VERSION 1.1.0
     DESCRIPTION "Standalone C++ library for reading RDS files"
     LANGUAGES CXX)
 

--- a/include/rds2cpp/parse_attributes.hpp
+++ b/include/rds2cpp/parse_attributes.hpp
@@ -10,16 +10,16 @@
 
 namespace rds2cpp {
 
-template<class Reader>
-PairList parse_pairlist_body(Reader&, std::vector<unsigned char>&, const Header&, SharedParseInfo&);
+template<class Source_>
+PairList parse_pairlist_body(Source_&, const Header&, SharedParseInfo&);
 
 inline bool has_attributes(const Header& header) {
     return (header[2] & 0x2);
 }
 
-template<class Reader>
-void parse_attributes_body(Reader& reader, std::vector<unsigned char>& leftovers, const Header& header, Attributes& output, SharedParseInfo& shared) try {
-    auto plist = parse_pairlist_body(reader, leftovers, header, shared);
+template<class Source_>
+void parse_attributes_body(Source_& src, const Header& header, Attributes& output, SharedParseInfo& shared) try {
+    auto plist = parse_pairlist_body(src, header, shared);
 
     size_t nnodes = plist.data.size();
     for (size_t t = 0; t < nnodes; ++t) {
@@ -35,13 +35,13 @@ void parse_attributes_body(Reader& reader, std::vector<unsigned char>& leftovers
     throw traceback("failed to parse attribute contents", e);
 }
 
-template<class Reader>
-void parse_attributes(Reader& reader, std::vector<unsigned char>& leftovers, Attributes& output, SharedParseInfo& shared) try {
-    auto header = parse_header(reader, leftovers);
+template<class Source_>
+void parse_attributes(Source_& src, Attributes& output, SharedParseInfo& shared) try {
+    auto header = parse_header(src);
     if (header[3] != static_cast<unsigned>(SEXPType::LIST)) {
         throw std::runtime_error("attributes should be a pairlist");
     }
-    parse_attributes_body(reader, leftovers, header, output, shared);
+    parse_attributes_body(src, header, output, shared);
     return;
 } catch (std::exception& e) {
     throw traceback("failed to parse attributes", e);

--- a/include/rds2cpp/parse_builtin.hpp
+++ b/include/rds2cpp/parse_builtin.hpp
@@ -9,18 +9,19 @@
 
 namespace rds2cpp {
 
-template<class Reader>
-BuiltInFunction parse_builtin_body(Reader& reader, std::vector<unsigned char>& leftovers) try {
-    size_t len = get_length(reader, leftovers);
+template<class Source_>
+BuiltInFunction parse_builtin_body(Source_& src) try {
+    size_t len = get_length(src);
 
     BuiltInFunction output;
-    extract_up_to(reader, leftovers, len,
-        [&](const unsigned char* buffer, size_t n, size_t) -> void {
-            auto ptr = reinterpret_cast<const char*>(buffer);
-            output.name.insert(output.name.end(), ptr, ptr + n);
+    output.name.resize(len);
+    for (size_t i = 0; i < len; ++i) {
+        if (!src.advance()) {
+            throw empty_error();
         }
-    );
-    
+        output.name[i] = src.get();
+    }
+
     return output;
 } catch(std::exception& e) {
     throw traceback("failed to parse built-in function body", e);

--- a/include/rds2cpp/parse_expression.hpp
+++ b/include/rds2cpp/parse_expression.hpp
@@ -10,15 +10,15 @@
 
 namespace rds2cpp {
 
-template<class Reader>
-std::unique_ptr<RObject> parse_object(Reader&, std::vector<unsigned char>&, SharedParseInfo& shared);
+template<class Source_>
+std::unique_ptr<RObject> parse_object(Source_&, SharedParseInfo& shared);
 
-template<class Reader>
-ExpressionVector parse_expression_body(Reader& reader, std::vector<unsigned char>& leftovers, SharedParseInfo& shared) try {
-    size_t len = get_length(reader, leftovers);
+template<class Source_>
+ExpressionVector parse_expression_body(Source_& src, SharedParseInfo& shared) try {
+    size_t len = get_length(src);
     ExpressionVector output(len);
     for (size_t i = 0; i < len; ++i) {
-        output.data[i] = parse_object(reader, leftovers, shared);
+        output.data[i] = parse_object(src, shared);
     }
     return output;
 } catch (std::exception& e) {

--- a/include/rds2cpp/parse_external_pointer.hpp
+++ b/include/rds2cpp/parse_external_pointer.hpp
@@ -12,18 +12,18 @@
 
 namespace rds2cpp {
 
-template<class Reader>
-std::unique_ptr<RObject> parse_object(Reader& reader, std::vector<unsigned char>& leftovers, SharedParseInfo& shared);
+template<class Source_>
+std::unique_ptr<RObject> parse_object(Source_& src, SharedParseInfo& shared);
 
-template<class Reader>
-ExternalPointerIndex parse_external_pointer_body(Reader& reader, std::vector<unsigned char>& leftovers, const Header& header, SharedParseInfo& shared) try {
+template<class Source_>
+ExternalPointerIndex parse_external_pointer_body(Source_& src, const Header& header, SharedParseInfo& shared) try {
     auto idx = shared.request_external_pointer();
     auto& extptr = shared.external_pointers[idx];
 
-    extptr.protection = parse_object(reader, leftovers, shared);
-    extptr.tag = parse_object(reader, leftovers, shared);
+    extptr.protection = parse_object(src, shared);
+    extptr.tag = parse_object(src, shared);
     if (has_attributes(header)) {
-        parse_attributes(reader, leftovers, extptr.attributes, shared);
+        parse_attributes(src, extptr.attributes, shared);
     }
 
     return ExternalPointerIndex(idx);

--- a/include/rds2cpp/parse_language.hpp
+++ b/include/rds2cpp/parse_language.hpp
@@ -12,14 +12,14 @@
 
 namespace rds2cpp {
 
-template<class Reader>
-PairList parse_pairlist_body(Reader&, std::vector<unsigned char>&, const Header&, SharedParseInfo&);
+template<class Source_>
+PairList parse_pairlist_body(Source_&, const Header&, SharedParseInfo&);
 
-template<class Reader>
-LanguageObject parse_language_body(Reader& reader, std::vector<unsigned char>& leftovers, const Header& header, SharedParseInfo& shared) try {
+template<class Source_>
+LanguageObject parse_language_body(Source_& src, const Header& header, SharedParseInfo& shared) try {
     LanguageObject output;
 
-    auto contents = parse_pairlist_body(reader, leftovers, header, shared);
+    auto contents = parse_pairlist_body(src, header, shared);
     output.attributes = std::move(contents.attributes);
 
     if (contents.has_tag.size() < 1) {

--- a/include/rds2cpp/parse_list.hpp
+++ b/include/rds2cpp/parse_list.hpp
@@ -10,16 +10,16 @@
 
 namespace rds2cpp {
 
-template<class Reader>
-std::unique_ptr<RObject> parse_object(Reader&, std::vector<unsigned char>&, SharedParseInfo& shared);
+template<class Source_>
+std::unique_ptr<RObject> parse_object(Source_&, SharedParseInfo& shared);
 
-template<class Reader>
-GenericVector parse_list_body(Reader& reader, std::vector<unsigned char>& leftovers, SharedParseInfo& shared) try {
-    size_t len = get_length(reader, leftovers);
+template<class Source_>
+GenericVector parse_list_body(Source_& src, SharedParseInfo& shared) try {
+    size_t len = get_length(src);
     GenericVector output(len);
     for (size_t i = 0; i < len; ++i) {
         try {
-            output.data[i] = parse_object(reader, leftovers, shared);
+            output.data[i] = parse_object(src, shared);
         } catch (std::exception& e) {
             throw traceback("failed to parse list element " + std::to_string(i + 1), e);
         }

--- a/include/rds2cpp/parse_rds.hpp
+++ b/include/rds2cpp/parse_rds.hpp
@@ -147,13 +147,15 @@ RdsFile parse_rds(Reader_& reader) {
 /**
  * Parse the contents of an RDS file.
  *
+ * @tparam parallel_ Whether to read and parse the file in parallel.
  * @param file Path to an RDS file.
  *
  * @return An `RdsFile` object containing the contents of `file`.
  */
-inline RdsFile parse_rds(std::string file) {
+template<bool parallel_ = false>
+RdsFile parse_rds(std::string file) {
     byteme::SomeFileReader reader(file.c_str());
-    return parse_rds(reader);
+    return parse_rds<parallel_>(reader);
 }
 
 /**

--- a/include/rds2cpp/parse_s4.hpp
+++ b/include/rds2cpp/parse_s4.hpp
@@ -10,26 +10,26 @@
 
 namespace rds2cpp {
 
-template<class Reader>
-std::unique_ptr<RObject> parse_object(Reader&, std::vector<unsigned char>&, SharedParseInfo&);
+template<class Source_>
+std::unique_ptr<RObject> parse_object(Source_&, SharedParseInfo&);
 
-template<class Reader>
-PairList parse_pairlist_body(Reader&, std::vector<unsigned char>&, const Header&, SharedParseInfo&);
+template<class Source_>
+PairList parse_pairlist_body(Source_&, const Header&, SharedParseInfo&);
 
-template<class Reader>
-S4Object parse_s4_body(Reader& reader, std::vector<unsigned char>& leftovers, const Header& header, SharedParseInfo& shared) try {
+template<class Source_>
+S4Object parse_s4_body(Source_& src, const Header& header, SharedParseInfo& shared) try {
     if (!(header[2] & 0x2) || !(header[2] & 0x1) || !(header[1] & 0x1)) {
         throw std::runtime_error("S4 objects should have object, attribute, and gp-S4 bits set in header");
     }
 
     S4Object output;
 
-    auto slot_header = parse_header(reader, leftovers);
+    auto slot_header = parse_header(src);
     if (slot_header[3] != static_cast<unsigned char>(SEXPType::LIST)) {
         throw std::runtime_error("slots of an S4 object should be stored as a pairlist");
     }
 
-    auto slot_plist = parse_pairlist_body(reader, leftovers, slot_header, shared);
+    auto slot_plist = parse_pairlist_body(src, slot_header, shared);
     size_t nslots = slot_plist.data.size();
     bool found_class = false;
 

--- a/include/rds2cpp/parse_symbol.hpp
+++ b/include/rds2cpp/parse_symbol.hpp
@@ -13,8 +13,8 @@
 namespace rds2cpp {
 
 template<class Reader>
-SymbolIndex parse_symbol_body(Reader& reader, std::vector<unsigned char>& leftovers, SharedParseInfo& shared) try {
-    auto str = parse_single_string(reader, leftovers);
+SymbolIndex parse_symbol_body(Reader& reader, SharedParseInfo& shared) try {
+    auto str = parse_single_string(reader);
     if (str.missing) {
         throw new std::runtime_error("expected a non-missing string for a symbol");
     }

--- a/tests/R/RcppExports.R
+++ b/tests/R/RcppExports.R
@@ -7,6 +7,11 @@ parse <- function(file_name) {
 }
 
 #' @export
+parallel_parse <- function(file_name) {
+    .Call('_rds2cpp_parallel_parse', PACKAGE = 'rds2cpp', file_name)
+}
+
+#' @export
 write <- function(x, file_name) {
     .Call('_rds2cpp_write', PACKAGE = 'rds2cpp', x, file_name)
 }

--- a/tests/src/RcppExports.cpp
+++ b/tests/src/RcppExports.cpp
@@ -20,6 +20,16 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// parallel_parse
+Rcpp::RObject parallel_parse(std::string file_name);
+RcppExport SEXP _rds2cpp_parallel_parse(SEXP file_nameSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::traits::input_parameter< std::string >::type file_name(file_nameSEXP);
+    rcpp_result_gen = Rcpp::wrap(parallel_parse(file_name));
+    return rcpp_result_gen;
+END_RCPP
+}
 // write
 Rcpp::RObject write(Rcpp::RObject x, std::string file_name);
 RcppExport SEXP _rds2cpp_write(SEXP xSEXP, SEXP file_nameSEXP) {
@@ -34,6 +44,7 @@ END_RCPP
 
 static const R_CallMethodDef CallEntries[] = {
     {"_rds2cpp_parse", (DL_FUNC) &_rds2cpp_parse, 1},
+    {"_rds2cpp_parallel_parse", (DL_FUNC) &_rds2cpp_parallel_parse, 1},
     {"_rds2cpp_write", (DL_FUNC) &_rds2cpp_write, 2},
     {NULL, NULL, 0}
 };

--- a/tests/src/parse.cpp
+++ b/tests/src/parse.cpp
@@ -185,10 +185,7 @@ Rcpp::RObject convert(const rds2cpp::RObject* input) {
     return R_NilValue;
 }
 
-//' @export
-//[[Rcpp::export(rng=false)]]
-Rcpp::RObject parse(std::string file_name) {
-    auto output = rds2cpp::parse_rds(file_name);
+Rcpp::RObject parse_output(const rds2cpp::RdsFile& output) {
     if (output.object == nullptr) {
         return R_NilValue;
     } 
@@ -259,4 +256,18 @@ Rcpp::RObject parse(std::string file_name) {
         Rcpp::Named("symbols") = all_symb,
         Rcpp::Named("external_pointers") = all_exts
     );
+}
+
+//' @export
+//[[Rcpp::export(rng=false)]]
+Rcpp::RObject parse(std::string file_name) {
+    auto output = rds2cpp::parse_rds(file_name);
+    return parse_output(output);
+}
+
+//' @export
+//[[Rcpp::export(rng=false)]]
+Rcpp::RObject parallel_parse(std::string file_name) {
+    auto output = rds2cpp::parse_rds<true>(file_name);
+    return parse_output(output);
 }

--- a/tests/tests/testthat/test-atomic.R
+++ b/tests/tests/testthat/test-atomic.R
@@ -21,6 +21,9 @@ test_that("integer vector loading works as expected", {
         saveRDS(y, file=tmp)
         roundtrip <- rds2cpp:::parse(tmp)
         expect_identical(roundtrip$value, y)
+
+        roundtrip <- rds2cpp:::parallel_parse(tmp)
+        expect_identical(roundtrip$value, y)
     }
 })
 


### PR DESCRIPTION
Fixes #9.